### PR TITLE
CI: use Node 24 and run frontend `pnpm` build in frontend directory

### DIFF
--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -82,13 +82,15 @@ jobs:
       - uses: actions/setup-node@v4
         if: steps.cache-check.outputs.cache-hit != 'true'
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "pnpm"
           cache-dependency-path: "./filebrowser/frontend/pnpm-lock.yaml"
       - name: Build frontend
         if: steps.cache-check.outputs.cache-hit != 'true'
-        run: make build-frontend
-        working-directory: "./filebrowser"
+        working-directory: "./filebrowser/frontend"
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
 
       - name: Set up QEMU
         if: steps.cache-check.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Motivation
- Align the GitHub Actions frontend build with the frontend package tooling by moving to Node `24.x` and invoking `pnpm` directly in the frontend package directory. 

### Description
- Update `actions/setup-node` `node-version` from `22.x` to `24.x` and keep pnpm caching in place. 
- Change the frontend build step to use `working-directory: ./filebrowser/frontend` and replace `make build-frontend` with `pnpm install --frozen-lockfile` followed by `pnpm run build`. 
- Retain `pnpm/action-setup@v4`, Docker/QEMU setup, and Docker metadata steps; no other workflow semantics were changed. 

### Testing
- Executed the `check-and-build` GitHub Actions workflow which ran the frontend `pnpm` install and build, Go version detection, and Docker metadata steps; the CI workflow completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a95399a5f48331863f61ef951ed408)